### PR TITLE
a StatefulSet without consecutive pods

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -404,3 +404,13 @@ func (ao ascendingOrdinal) Swap(i, j int) {
 func (ao ascendingOrdinal) Less(i, j int) bool {
 	return getOrdinal(ao[i]) < getOrdinal(ao[j])
 }
+
+func findPod(ordinal int, pods []*v1.Pod) *v1.Pod, error {
+    for _, pod := pods {
+        if getOrdinal(pod) == ordinal {
+            return pod, nil
+        }
+    }
+    return nil, fmt.Errorf("ordinal %d not found", ordinal)
+
+}


### PR DESCRIPTION
Change the code to not assume that the ordinal has any meaning beyond
identity. An ordinal should never be re-used across pods with different
identity. A pod can be re-created with the same ordinal.

Assuming the presence of consecutive pods is not compatible
with fault-tolerant stateful services.

For example, during a failure we need to create a new pod with a new
identity and wait for data to replicate to it.
If the failed pod does not come online then we delete it.
This will leave a hole in the consecutive ordinals.
That failed pod should be permanently gone.
Filling its hole with a new pod can lead to a confusion of identity.

# TODO

- [ ] Design for the new, non-consecutive identifier
- [ ] run test suite
- [ ] additional testing & verification

## Non-consecutive identifier

There are several approaches here
1) use the pod uuid
2) generate a small random string
3) maintain a monotonic counter

I favor the third because it creates a small, easy to use identifier. This will require placing an annotation on the StatefulSet of the highest counter value (for when pods are deleted). If a StatefulSet is deleted, but the pods are retained, and then we want to re-create the statefulset, we would need to place the annotation from the StatefulSet onto all its Pods when the StatefulSet is deleted.
